### PR TITLE
feat: Integrate OpenAI embeddings as a featurizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ examples/archive
 */experimental.py
 docs
 build
-
+.env
 # gemini-cli settings
 .gemini/
 # GitHub App credentials

--- a/consent/__init__.py
+++ b/consent/__init__.py
@@ -1,1 +1,1 @@
-from .consent import *
+from .consent import ConSent, OpenAIEncoder, Config

--- a/consent/__init__.py
+++ b/consent/__init__.py
@@ -1,1 +1,1 @@
-from .consent import ConSent, OpenAIEncoder, Config
+from .consent import ConSent, OpenAIEncoder, Config, HYPERPARAMETERS

--- a/consent/__init__.py
+++ b/consent/__init__.py
@@ -1,1 +1,1 @@
-from .consent import ConSent, OpenAIEncoder, Config, HYPERPARAMETERS
+from .consent import ConSent, OpenAIEncoder, Config, HYPERPARAMETERS, wandb

--- a/consent/openai_encoder.py
+++ b/consent/openai_encoder.py
@@ -1,0 +1,42 @@
+import os
+import openai
+import tensorflow as tf
+import numpy as np
+
+class OpenAIEncoder(tf.keras.layers.Layer):
+    def __init__(self, model_name, **kwargs):
+        super(OpenAIEncoder, self).__init__(**kwargs)
+        self.model_name = model_name
+        self.client = openai.OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
+        # Assuming text-embedding-3-small, which has a dimension of 1536
+        self.embedding_dim = 1536
+
+    def _get_embeddings(self, inputs):
+        embeddings = []
+        for text_tensor in inputs:
+            text = text_tensor.numpy().decode('utf-8')[:140]
+            response = self.client.embeddings.create(
+                input=text,
+                model=self.model_name
+            )
+            embeddings.append(response.data[0].embedding)
+        return np.array(embeddings, dtype=np.float32)
+
+    def call(self, inputs):
+        embeddings = tf.py_function(
+            self._get_embeddings,
+            [inputs],
+            tf.float32
+        )
+        embeddings.set_shape((None, self.embedding_dim))
+        return embeddings
+
+    def compute_output_shape(self, input_shape):
+        return (input_shape[0], self.embedding_dim)
+
+    def get_config(self):
+        config = super().get_config()
+        config.update({
+            "model_name": self.model_name
+        })
+        return config

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ tensorflow-text==2.19.0
 tensorflow-hub
 wandb==0.12.11
 protobuf<=3.20.3
+openai
+tiktoken


### PR DESCRIPTION
This commit introduces the ability to use OpenAI embeddings as a language featurizer for training ConSent models.

Changes:
- New `OpenAIEncoder` Keras Layer to handle interactions with the OpenAI API.
- Integration with `ConSent` model to support `openai/` prefix in the `language_featurizer` configuration.
- Added `openai` and `tiktoken` to `requirements.txt`.
- Added unit tests with mocking for the `OpenAIEncoder`.
- Updated `.gitignore` to allow for `.env` files.